### PR TITLE
Copy files instead of symlinking

### DIFF
--- a/linux-4.14.bz
+++ b/linux-4.14.bz
@@ -1,1 +1,3 @@
-linux-4.14.183.bz
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f97b97105a3e18dc23ef912266858e55c8e63cb52c1f66e707bad5e803c5e1e
+size 6787536

--- a/linux-4.19.bz
+++ b/linux-4.19.bz
@@ -1,1 +1,3 @@
-linux-4.19.127.bz
+version https://git-lfs.github.com/spec/v1
+oid sha256:591cf61509a62389be245a07c2c04eab1068e8fcf696e770771b13e87f6a5912
+size 7213616

--- a/linux-4.9.bz
+++ b/linux-4.9.bz
@@ -1,1 +1,3 @@
-linux-4.9.226.bz
+version https://git-lfs.github.com/spec/v1
+oid sha256:517a27e8671609ffee492558a5bb72587941c800a5dbbe29195aaadc4dd09a59
+size 5665264

--- a/linux-5.4.bz
+++ b/linux-5.4.bz
@@ -1,1 +1,3 @@
-linux-5.4.45.bz
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0939c887d263416b8cceb6107dd3b889d679c4ff98155950772ec773ad01c12
+size 8590720

--- a/linux-5.7.bz
+++ b/linux-5.7.bz
@@ -1,1 +1,3 @@
-linux-5.7.1.bz
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e307bdbad647b89e6f4d6ab02d93d18613fcdb527970360176ad28d6357e2b0
+size 8566080

--- a/make.sh
+++ b/make.sh
@@ -34,9 +34,7 @@ for kernel_version in "${kernel_versions[@]}"; do
 	mv "arch/x86/boot/bzImage" "${script_dir}/linux-${kernel_version}.bz"
 	popd
 
-	pushd "${script_dir}"
-	ln -sf "linux-${kernel_version}.bz" "linux-${major_version}.bz"
-	popd
+	cp -f "${script_dir}/linux-${kernel_version}.bz" "${script_dir}/linux-${major_version}.bz"
 done
 
 


### PR DESCRIPTION
git-lfs doesn't seem to work with symlinks. Copy the files instead, and
rely on git-lfs to deduplicate the blobs.