### PR TITLE
Add 5.10

### DIFF
--- a/linux-5.10-selftests-bpf.bz
+++ b/linux-5.10-selftests-bpf.bz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:265c3561cad70d9124c885850107d254824a119d63b685a3272bb677244b1b69
+size 19701564

--- a/linux-5.10.9-selftests-bpf.bz
+++ b/linux-5.10.9-selftests-bpf.bz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:265c3561cad70d9124c885850107d254824a119d63b685a3272bb677244b1b69
+size 19701564

--- a/linux-5.10.9.bz
+++ b/linux-5.10.9.bz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf82d35a0ad801b500dd1b63b29e4018632ccdbb68932d4917bc4aae256648c0
+size 9133664

--- a/linux-5.10.bz
+++ b/linux-5.10.bz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf82d35a0ad801b500dd1b63b29e4018632ccdbb68932d4917bc4aae256648c0
+size 9133664

--- a/make.sh
+++ b/make.sh
@@ -10,60 +10,75 @@ readonly build_dir="${script_dir}/build"
 
 mkdir -p "${build_dir}"
 
-readonly kernel_versions=("4.9.248" "4.14.212" "4.19.163" "5.4.83" "5.9.6")
+fetch_and_configure() {
+	local kernel_version="$1"
+	local src_dir="${build_dir}/linux-${kernel_version}"
+	local archive="${build_dir}/linux-${kernel_version}.tar.xz"
+
+	test -e "${archive}" || curl --fail -L "https://cdn.kernel.org/pub/linux/kernel/v${kernel_version%%.*}.x/linux-${kernel_version}.tar.xz" -o "${archive}" 1>&2
+	test -d "${src_dir}" || tar --xz -xf "${archive}" -C "${build_dir}" 1>&2
+
+	cd "${src_dir}"
+	if [[ ! -f custom.config || "${script_dir}/config" -nt custom.config ]]; then
+		make KCONFIG_CONFIG=custom.config defconfig 1>&2
+		cat "${script_dir}/config" >> custom.config 1>&2
+		make allnoconfig KCONFIG_ALLCONFIG="custom.config" 1>&2
+		virtme-configkernel --update 1>&2
+	fi
+
+	echo "${src_dir}"
+}
+
+readonly kernel_versions=("4.9.248" "4.14.212" "4.19.163" "5.4.83" "5.10.9")
 for kernel_version in "${kernel_versions[@]}"; do
+	series="$(echo "$kernel_version" | cut -d . -f 1-2)"
+
 	if [[ -f "linux-${kernel_version}.bz" ]]; then
 		echo "Skipping ${kernel_version}, it already exist"
+	else
+		cd "$(fetch_and_configure "$kernel_version")"
+		make clean
+		make -j7 bzImage
+
+		cp "arch/x86/boot/bzImage" "${script_dir}/linux-${kernel_version}.bz"
+		if [ "$kernel_version" != "$series" ]; then
+			cp -f "${script_dir}/linux-${kernel_version}.bz" "${script_dir}/linux-${series}.bz"
+		fi
+	fi
+
+	if [[ -f "linux-${kernel_version}-selftests-bpf.bz" ]]; then
+		echo "Skipping selftests for ${kernel_version}, they already exist"
 		continue
 	fi
 
-	src_dir="${build_dir}/linux-${kernel_version}"
-	archive="${build_dir}/linux-${kernel_version}.tar.xz"
-	series="$(echo "$kernel_version" | cut -d . -f 1-2)"
-
-	test -e "${archive}" || curl --fail -L "https://cdn.kernel.org/pub/linux/kernel/v${kernel_version%%.*}.x/linux-${kernel_version}.tar.xz" -o "${archive}"
-	test -d "${src_dir}" || tar --xz -xf "${archive}" -C "${build_dir}"
-
-	pushd "${src_dir}"
-	make KCONFIG_CONFIG=custom.config defconfig
-	cat "${script_dir}/config" >> "${src_dir}/custom.config"
-	make allnoconfig KCONFIG_ALLCONFIG="custom.config"
-	virtme-configkernel --update
-
-	make clean
-	make -j7 bzImage
-
-	cp "arch/x86/boot/bzImage" "${script_dir}/linux-${kernel_version}.bz"
-	if [ "$kernel_version" != "$series" ]; then
-		cp -f "${script_dir}/linux-${kernel_version}.bz" "${script_dir}/linux-${series}.bz"
+	if [[ "${series}" = "4.9" ]]; then
+		echo "No selftests on 4.9"
+		continue
 	fi
 
-	if [ -d "tools/testing/selftests/bpf" ]; then
-		if [ "${series}" = "4.14" ]; then
-			inc="$(find /usr/include -iregex '.+/asm/bitsperlong\.h$' | head -n 1)"
-			export CLANG="$clang '-I${inc%asm/bitsperlong.h}'"
-		else
-			export CLANG="$clang"
-		fi
+	cd "$(fetch_and_configure "$kernel_version")"
 
-		export LLC="$llc"
+	if [ "${series}" = "4.14" ]; then
+		inc="$(find /usr/include -iregex '.+/asm/bitsperlong\.h$' | head -n 1)"
+		export CLANG="$clang '-I${inc%asm/bitsperlong.h}'"
+	else
+		export CLANG="$clang"
+	fi
 
-		make -C tools/testing/selftests/bpf
-		while IFS= read -r obj; do
-			if readelf -h "$obj" | grep -q "Linux BPF"; then
-				if [ "${series}" = "4.19" ]; then
-					# Remove .BTF.ext, since .BTF is rewritten by pahole.
-					# See https://lore.kernel.org/bpf/CACAyw9-cinpz=U+8tjV-GMWuth71jrOYLQ05Q7_c34TCeMJxMg@mail.gmail.com/
-					llvm-objcopy --remove-section .BTF.ext "$obj" 1>&2
-				fi
-				echo "$obj"
+	export LLC="$llc"
+
+	make -C tools/testing/selftests/bpf
+	while IFS= read -r obj; do
+		if readelf -h "$obj" | grep -q "Linux BPF"; then
+			if [ "${series}" = "4.19" ]; then
+				# Remove .BTF.ext, since .BTF is rewritten by pahole.
+				# See https://lore.kernel.org/bpf/CACAyw9-cinpz=U+8tjV-GMWuth71jrOYLQ05Q7_c34TCeMJxMg@mail.gmail.com/
+				llvm-objcopy --remove-section .BTF.ext "$obj" 1>&2
 			fi
-		done < <(find tools/testing/selftests/bpf -type f -name "*.o") | tar cvjf "${script_dir}/linux-${kernel_version}-selftests-bpf.bz" -T -
-		if [ "$kernel_version" != "$series" ]; then
-			cp -f "${script_dir}/linux-${kernel_version}-selftests-bpf.bz" "${script_dir}/linux-${series}-selftests-bpf.bz"
+			echo "$obj"
 		fi
+	done < <(find tools/testing/selftests/bpf -type f -name "*.o") | tar cvjf "${script_dir}/linux-${kernel_version}-selftests-bpf.bz" -T -
+	if [ "$kernel_version" != "$series" ]; then
+		cp -f "${script_dir}/linux-${kernel_version}-selftests-bpf.bz" "${script_dir}/linux-${series}-selftests-bpf.bz"
 	fi
-	popd
 done
-
-


### PR DESCRIPTION
I had to cheat with this one, since the selftests only compile with clang-12.
There is a patch pending for the next 5.10 release which should fix this. At
that point we can rebuild all selftests with clang-11.