### PR TITLE
rebuild kernel 4.14

### DIFF
--- a/linux-4.14-selftests-bpf.tgz
+++ b/linux-4.14-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4512aaae4faca2f112d20ffbd012c89dfab2d8801ccd92c8e38ff552831500f
-size 5957
+oid sha256:52edfa4dd74df62f7d2236bb62f4662ddac56266a2684f38fbe9a9d556f605a3
+size 5923

--- a/linux-4.14.264-selftests-bpf.tgz
+++ b/linux-4.14.264-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4512aaae4faca2f112d20ffbd012c89dfab2d8801ccd92c8e38ff552831500f
-size 5957
+oid sha256:52edfa4dd74df62f7d2236bb62f4662ddac56266a2684f38fbe9a9d556f605a3
+size 5923

--- a/linux-4.14.264.bz
+++ b/linux-4.14.264.bz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42e3959491929a7edda77730f1ef5f17563055bd6c7f8940d5db5e365c99a0af
+oid sha256:a1df72abb020c1e8fab5a74da3458c9f598c56bcfd4959719a32f97b26225e5f
 size 7197088

--- a/linux-4.14.bz
+++ b/linux-4.14.bz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:720cf90015a1c4dcc7e8c65d6aa279d68760b910c31c643f4591e51bc52661b5
-size 275
+oid sha256:a1df72abb020c1e8fab5a74da3458c9f598c56bcfd4959719a32f97b26225e5f
+size 7197088


### PR DESCRIPTION
Rebuild 4.14 as I am getting `qemu: linux kernel too old to load a ram disk` while tests run fine on 4.4 and 4.9