### PR TITLE
Fix link to podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ci-kernels
 
-A collection of kernels used for CI builds. You'll need [podman]() to run the build.
+A collection of kernels used for CI builds. You'll need [podman] to run the build.
 
 1. Update kernel versions in `make.sh`
 2. `make`


### PR DESCRIPTION
With the additional `()` after `[podman]` clicking the link directs to https://github.com/cilium/ci-kernels/blob/master instead of https://podman.io.

Signed-off-by: Florian Lehner <florianl@users.noreply.github.com>