### PR TITLE
make.sh: fix packaging of bpf_testmod.ko

### DIFF
--- a/linux-5.15-selftests-bpf.tgz
+++ b/linux-5.15-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e7c7e893dad2a454c3463590410c23a2e6c5b3f0ee371c4fa8787c59ec25737
-size 16501679
+oid sha256:d8d575d428560bece16a3a4a75a050d83ae1cdeb47e991daec72e085bc42f296
+size 16595001

--- a/linux-5.15.68-selftests-bpf.tgz
+++ b/linux-5.15.68-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e7c7e893dad2a454c3463590410c23a2e6c5b3f0ee371c4fa8787c59ec25737
-size 16501679
+oid sha256:d8d575d428560bece16a3a4a75a050d83ae1cdeb47e991daec72e085bc42f296
+size 16595001

--- a/linux-5.19-selftests-bpf.tgz
+++ b/linux-5.19-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc27e565a99b2b5fab9960df48f5e7277bb6cf0c8a516ffc57e6f5acb857dd8e
-size 21363676
+oid sha256:d9abc7ab2bac07f72b3a28974f09da2a9c2d942af881464e5b378f0e09e6f2db
+size 21461424

--- a/linux-5.19.9-selftests-bpf.tgz
+++ b/linux-5.19.9-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc27e565a99b2b5fab9960df48f5e7277bb6cf0c8a516ffc57e6f5acb857dd8e
-size 21363676
+oid sha256:d9abc7ab2bac07f72b3a28974f09da2a9c2d942af881464e5b378f0e09e6f2db
+size 21461424

--- a/make.sh
+++ b/make.sh
@@ -119,7 +119,11 @@ for kernel_version in "${kernel_versions[@]}"; do
 			llvm-objcopy --remove-section .BTF.ext "$obj" 1>&2
 		fi
 		echo "$obj"
-	done < <(find tools/testing/selftests/bpf/. -name . -o -type d -prune -o -type f \( -name "*.o" -o -name "bpf_testmod.ko" \) -print) | tar cvf "${script_dir}/linux-${kernel_version}-selftests-bpf.tar" -T -
+	done < <(find tools/testing/selftests/bpf/. -name . -o -type d -prune -o -type f -name "*.o" -print) | tar cvf "${script_dir}/linux-${kernel_version}-selftests-bpf.tar" -T -
+
+	if [[ -f "tools/testing/selftests/bpf/bpf_testmod/bpf_testmod.ko" ]]; then
+		tar rvf "${script_dir}/linux-${kernel_version}-selftests-bpf.tar" "tools/testing/selftests/bpf/bpf_testmod/bpf_testmod.ko"
+	fi
 
 	gzip -9 "${script_dir}/linux-${kernel_version}-selftests-bpf.tar"
 	mv "${script_dir}/linux-${kernel_version}-selftests-bpf.tar.gz" "${script_dir}/linux-${kernel_version}-selftests-bpf.tgz"


### PR DESCRIPTION
Roll back the previous change meant to speed up packaging of bpf_testmod.ko. It doesn't work since bpf_testmod.ko is not a BPF ELF and is therefore filtered out by the while loop.