### PR TITLE
fix missing /proc/config.gz for 4.9 and 5.19

### DIFF
--- a/linux-4.9.337.bz
+++ b/linux-4.9.337.bz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59fba757af57334055a94868efc2fabec199395f6c54cf4d88eba3207ddcc201
-size 5980608
+oid sha256:be3f2c548948151f3856ffed2fbf13a7c2471427228553e23ec704efa6ec0e01
+size 4899264

--- a/linux-4.9.bz
+++ b/linux-4.9.bz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59fba757af57334055a94868efc2fabec199395f6c54cf4d88eba3207ddcc201
-size 5980608
+oid sha256:be3f2c548948151f3856ffed2fbf13a7c2471427228553e23ec704efa6ec0e01
+size 4899264

--- a/linux-5.19-selftests-bpf.tgz
+++ b/linux-5.19-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38181cf12033eab77c6bc21eb4fd6cccffe2a86e71a27ff309a60ce132431c36
-size 21460913
+oid sha256:57af19cb03809eb342fba655080a6ea77c05ddf888f1602dc68ac2094617a3e1
+size 19117806

--- a/linux-5.19.16-selftests-bpf.tgz
+++ b/linux-5.19.16-selftests-bpf.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38181cf12033eab77c6bc21eb4fd6cccffe2a86e71a27ff309a60ce132431c36
-size 21460913
+oid sha256:57af19cb03809eb342fba655080a6ea77c05ddf888f1602dc68ac2094617a3e1
+size 19117806

--- a/linux-5.19.16.bz
+++ b/linux-5.19.16.bz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:208c8d403a71f4f54ce3deaef7bb7dc545a2360d2d5970ded22599c444b5d125
-size 11412128
+oid sha256:9742e8bfe4b23d7ce73d7921ab9d31dc23cf719a0e760bad442ef17e74765701
+size 9382336

--- a/linux-5.19.bz
+++ b/linux-5.19.bz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:208c8d403a71f4f54ce3deaef7bb7dc545a2360d2d5970ded22599c444b5d125
-size 11412128
+oid sha256:9742e8bfe4b23d7ce73d7921ab9d31dc23cf719a0e760bad442ef17e74765701
+size 9382336


### PR DESCRIPTION
I missed rebuilding kernels that didn't have a version bump.