### PR TITLE
make selftests tag a superset of pure kernel image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,6 @@ FROM scratch as vmlinux
 COPY --from=build-vmlinux /tmp/output /
 
 # Prepare the selftests image
-FROM scratch as selftests-bpf
+FROM vmlinux as selftests-bpf
 
-COPY --from=build-selftests /tmp/selftests /
+COPY --from=build-selftests /tmp/selftests /usr/src/linux


### PR DESCRIPTION
The -selftests tag currently doesn't contain the kernel itself. This doesn't make a lot of sense, since we always want the kernel if we download the selftests. This also makes the images a bit more consistent.