### PR TITLE
fix selftest image target

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -107,7 +107,7 @@ jobs:
       if: matrix.kernel_version == env.latest_stable
       uses: docker/build-push-action@v5
       with:
-        target: vmlinux
+        target: selftests-bpf
         platforms: |
           linux/amd64
         build-args: |


### PR DESCRIPTION
We're currently using the wrong target when building selftest images due to a copy pasta error.