### PR TITLE
CI: periodically remove untagged images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -78,9 +78,11 @@ jobs:
           type=raw,value=mainline,enable=${{ matrix.kernel_version == env.MAINLINE }}
           type=raw,value=stable,enable=${{ matrix.kernel_version == env.STABLE }}
         labels: |
+          org.opencontainers.image.licenses=GPLv2
           org.opencontainers.image.created=
           org.opencontainers.image.revision=
         annotations: |
+          org.opencontainers.image.licenses=GPLv2
           org.opencontainers.image.created=
           org.opencontainers.image.revision=
 
@@ -96,9 +98,11 @@ jobs:
           type=raw,value=mainline,suffix=-selftests,enable=${{ matrix.kernel_version == env.MAINLINE }}
           type=raw,value=stable,suffix=-selftests,enable=${{ matrix.kernel_version == env.STABLE }}
         labels: |
+          org.opencontainers.image.licenses=GPLv2
           org.opencontainers.image.created=
           org.opencontainers.image.revision=
         annotations: |
+          org.opencontainers.image.licenses=GPLv2
           org.opencontainers.image.created=
           org.opencontainers.image.revision=
 

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,0 +1,25 @@
+name: Cleanup Untagged Images
+
+on:
+  workflow_dispatch: []
+  schedule:
+    - cron: '1 23 * * *'
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Remove untagged images
+      run: |
+        ids=$(gh api -X GET "/orgs/${{ github.repository_owner }}/packages/container/ci-kernels/versions" -f package_type=container -F per_page=2 -q '.[] | select(.metadata.container.tags | length == 0) | .id')
+
+        for id in $ids; do
+            echo "Deleting untagged image with ID: $id"
+            gh api -X DELETE "/orgs/${{ github.repository_owner }}/packages/container/ci-kernels/versions/$id"
+          fi
+        done
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We keep overwriting tags, so the package accumulates old untagged images. Remove images without a tag once a day.