### PR TITLE
Update version.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,38 +1,38 @@
 [
   {
-    "version": "6.12-rc2",
+    "version": "6.14-rc3",
     "static_tag": "mainline"
   },
   {
-    "version": "6.11.1",
+    "version": "6.13.3",
     "static_tag": "stable"
   },
   {
-    "version": "6.10.13",
-    "static_tag": ""
-  },
-  {
-    "version": "6.6.41",
+    "version": "6.12.15",
     "static_tag": "longterm"
   },
   {
-    "version": "6.1.112",
+    "version": "6.6.78",
     "static_tag": ""
   },
   {
-    "version": "5.15.167",
+    "version": "6.1.128",
     "static_tag": ""
   },
   {
-    "version": "5.10.226",
+    "version": "5.15.178",
     "static_tag": ""
   },
   {
-    "version": "5.4.284",
+    "version": "5.10.234",
     "static_tag": ""
   },
   {
-    "version": "4.19.322",
+    "version": "5.4.290",
+    "static_tag": ""
+  },
+  {
+    "version": "4.19.325",
     "static_tag": ""
   }
 ]


### PR DESCRIPTION
Hi, 

its been ~5 months since the last update. 
6.12 is now longterm. 
Testing against newer kernels like 6.13 and 6.14 RC would be nice, I dont know about any relevant changes in there.

File updated by using `./update-versions.sh` and manually added 4.19.325 (last) to keep testing against it.
