### PR TITLE
package python debug scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN if [ -d tools/testing/selftests/bpf/test_kmods ]; then \
         ln -s usr/lib /tmp/output/lib; \
     fi
 
-FROM build-vmlinux as build-vmlinux-debug
+FROM build-vmlinux AS build-vmlinux-debug
 
 # Package debug info
 RUN mkdir -p /tmp/debug/boot
@@ -54,7 +54,7 @@ COPY copy-debug.sh filter-debug.awk .
 RUN ./copy-debug.sh /tmp/debug
 
 # Build selftests
-FROM build-vmlinux as build-selftests
+FROM build-vmlinux AS build-selftests
 
 ARG BUILDPLATFORM
 
@@ -72,28 +72,28 @@ COPY copy-selftests.sh .
 RUN mkdir /tmp/selftests && ./copy-selftests.sh /tmp/selftests
 
 # Prepare the final kernel image
-FROM scratch as vmlinux
+FROM scratch AS vmlinux
 
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 COPY --from=build-vmlinux /tmp/output /
 
 # Debug
-FROM vmlinux as vmlinux-debug
+FROM vmlinux AS vmlinux-debug
 
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 COPY --from=build-vmlinux-debug /tmp/debug /
 
 # Prepare the selftests image
-FROM vmlinux as selftests-bpf
+FROM vmlinux AS selftests-bpf
 
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 COPY --from=build-selftests /tmp/selftests /usr/src/linux
 
 # Debug
-FROM vmlinux-debug as selftests-bpf-debug
+FROM vmlinux-debug AS selftests-bpf-debug
 
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ You can approximate CI by running `buildx.sh`:
 $ ./buildx.sh 6.1 amd64 vmlinux --tag foo:vmlinux
 ```
 
+To inspect the result of a build:
+
+```shell
+$ ./buildx.sh 6.1 amd64 build-vmlinux-debug
+...
+ => => writing image sha256:18d00182c5495376d87dfef5a4363a1b2cbd936af4f893ab437ce006b0f893d4                             0.0s
+$ docker run -it sha256:18d00182c5495376d87dfef5a4363a1b2cbd936af4f893ab437ce006b0f893d4
+root@1a64a0ade637:/usr/src/linux#
+```
+
 ## Updating versions
 
 Use `update-version.sh` (requires `jq`):

--- a/config
+++ b/config
@@ -24,6 +24,7 @@ CONFIG_VT=y
 
 # Make debugging in gdb work.
 CONFIG_RANDOMIZE_BASE=n
+CONFIG_GDB_SCRIPTS=y
 
 # Enable BPF related things
 # Please sort lines by alphabet ascending.

--- a/copy-debug.sh
+++ b/copy-debug.sh
@@ -9,6 +9,12 @@ readonly output="${1}"
 # Retain vmlinux which includes debug symbols
 cp vmlinux "$output/boot/"
 
+# Retain debug scripts
+mkdir -p "$output/usr/src/linux"
+cp -v vmlinux-gdb.py "$output/usr/src/linux"
+ln -s ../usr/src/linux/vmlinux-gdb.py "$output/boot/vmlinux-gdb.py"
+find . -path "*/scripts/gdb*" -type f -not -path "*/__pycache__*" -exec cp -v --parents {} "$output/usr/src/linux" \;
+
 # Retain only the sources referenced by dwarf debug info
 "${LLVM_DWARFDUMP}" "$output/boot/vmlinux" | \
 	awk -f filter-debug.awk | \


### PR DESCRIPTION
Fix buildx warning

    Get rid of the following:

         WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

Add instructions for how to inspect a build

    I keep forgetting what the commands are, add them to the readme.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

Package debug scripts

    See
    https://www.kernel.org/doc/html/latest/process/debugging/gdb-kernel-debugging.html

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
