### PR TITLE
config: add fanotify

### DIFF
--- a/config
+++ b/config
@@ -90,6 +90,10 @@ CONFIG_XDP_SOCKETS=y
 CONFIG_HW_RANDOM_VIRTIO=y
 CONFIG_VIRTIO_BALLOON=y
 
+# Other features useful to add in BTF
+CONFIG_FANOTIFY=y
+CONFIG_FANOTIFY_ACCESS_PERMISSIONS=y
+
 # Get rid of some drivers and obsolete features
 CONFIG_ATA=n
 CONFIG_DRM=n


### PR DESCRIPTION
I have some eBPF programs using the BTF definition of 'struct fsnotify_group' and attached on kprobe/fsnotify_remove_first_event and other fanotify functions. For this, I need a kernel with fanotify.